### PR TITLE
Feature: Add files to event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "sassc-rails"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "cloudinary"
 gem "devise"
 gem "geocoder"
 gem "autoprefixer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
+    aws_cf_signer (0.1.3)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -92,6 +93,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudinary (1.26.0)
+      aws_cf_signer
+      rest-client (>= 2.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -104,6 +108,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -116,6 +122,9 @@ GEM
     geocoder (1.8.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -137,6 +146,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.7.1)
@@ -149,6 +161,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.2-arm64-darwin)
       racc (~> 1.4)
@@ -199,6 +212,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -231,6 +249,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -261,6 +282,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   capybara
+  cloudinary
   debug
   devise
   dotenv-rails

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :set_trip, only: %i[show new create edit update]
+  before_action :set_trip, only: %i[show new create edit]
 
   def index
   end
@@ -24,7 +24,30 @@ class EventsController < ApplicationController
     end
   end
 
+  # MISSING: DELETE FILE
+  def add_file
+    @event = Event.find(params[:event_id])
+  end
+
+  def update
+    @event = Event.find(params[:id])
+    # fetch user's selected label for file
+    file_label = params[:file_label]
+    @event.update(event_params)
+    # update saved file with selected label in form
+    update_filename(file_label) if @event.files.attached?
+    redirect_to trip_event_path(@event.trip, @event)
+  end
+
   private
+
+  def update_filename(label)
+    # preserve original extension
+    extension = @event.files.last.filename.extension
+    # rename using user-selected label + original extension
+    filename = "#{label}.#{extension}"
+    @event.files.last.update(filename:)
+  end
 
   def set_trip
     @trip = Trip.find(params[:trip_id])
@@ -39,9 +62,11 @@ class EventsController < ApplicationController
                                   :end_location,
                                   :provider,
                                   :reservation_number,
+                                  :transport_number,
                                   :seat_number,
                                   :notes,
                                   :provider_phone,
-                                  :provider_email)
+                                  :provider_email,
+                                  :files)
   end
 end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -34,6 +34,9 @@ class TripsController < ApplicationController
     redirect_to trip_path(@trip)
   end
 
+  def add_file
+  end
+
   private
 
   def set_trip

--- a/app/inputs/fake_select_input.rb
+++ b/app/inputs/fake_select_input.rb
@@ -1,0 +1,13 @@
+class FakeSelectInput < SimpleForm::Inputs::CollectionSelectInput
+  def input(wrapper_options = nil)
+    label_method, value_method = detect_collection_methods
+
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options).merge(input_options.slice(:multiple, :include_blank, :disabled, :prompt))
+
+    template.select_tag(
+      attribute_name,
+      template.options_from_collection_for_select(collection, value_method, label_method, selected: input_options[:selected], disabled: input_options[:disabled]),
+      merged_input_options
+    )
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,7 @@ class Event < ApplicationRecord
   belongs_to :trip
 
   has_many :tasks, dependent: :destroy
+  has_many :files
 
   validates :event_type, inclusion: { in: EVENT_TYPES }
   validates :start_date, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,14 +1,16 @@
 class Event < ApplicationRecord
   EVENT_TYPES = %w[journey flight train bus boat rental stay restaurant show visit other]
+  FILE_LABELS = ["Boarding Pass", "Visa", "Passport", "Loyalty Card", "Vaccinations"]
 
   before_save :geocode_endpoints
   belongs_to :trip
 
   has_many :tasks, dependent: :destroy
-  has_many :files
+  has_many_attached :files
 
   validates :event_type, inclusion: { in: EVENT_TYPES }
   validates :start_date, presence: true
+  # MISSING: FIX VALIDATIONS - MOST EVENTS NEED START AND END DATES, AND START AND END LOCATIONS TO WORK
   # validates :end_date, presence: true, if: :journey? || :flight? || :train? || :bus? || :boat? || :stay?
   validates :name, presence: true, if: :other?
 

--- a/app/views/events/add_file.html.erb
+++ b/app/views/events/add_file.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for(@event) do |f| %>
+  <%# fake form input — not an actual paramater, just captures intended label for uploaded file %>
+  <%= f.input :file_label, as: :fake_select, collection: Event::FILE_LABELS %>
+  <%= f.input :files, as: :file %>
+  <%= f.submit 'Upload File'  %>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -127,7 +127,13 @@
       <h2>Files</h2>
     </div>
     <div>
-    <%= link_to "Add file",  "#", class: "btn btn-primary" %>
+     <% @event.files.each do |file| %>
+        <a href="" class="secondary-pill-button"><%= file.filename.base.upcase %></a>
+      <% end %>
+    </div>
+    <br>
+    <div>
+    <%= link_to "Add file", add_file_path(@event.trip, @event), class: "primary-button" %>
     </div>
   </div>
   <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ module Tripper
     end
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    # This ensures adding new files through active storage doesn't replace existong files
+    config.active_storage.replace_on_assign_to_many = false
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,10 @@ Rails.application.routes.draw do
   get '/components', to: 'pages#components'
   get '/uikitt', to: 'pages#uikitt'
   get '/eventstype', to: 'pages#eventstype'
+  get '/trips/:id/events/:event_id/add_file', to: 'events#add_file', as: 'add_file'
 
   resources :trips, only: %i[index show new create edit update] do
-    resources :events, only: %i[index show new create]
+    resources :events, only: %i[index show new create edit update]
   end
 
   # MISSING: Delete trip

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,10 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+cloudinary:
+  service: Cloudinary
+  folder: <%= Rails.env %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
- Allows uploading files to events
- One file at a time, but multiple files can be associated with a single event
- Feature renames file to match users selected label from the form dropdown (but preserves original file extension)
- Displays files as pill buttons on event show (needs visual refacto, though)
- Missing: delete a file